### PR TITLE
fix: 대시보드 아이템 2줄인 경우 간격 벌어지는 문제 수정

### DIFF
--- a/src/app/dashboard/page.module.css
+++ b/src/app/dashboard/page.module.css
@@ -32,6 +32,7 @@
   max-width: 1560px;
   min-height: 694px;
   flex-wrap: wrap;
+  align-content: flex-start;
   margin: 0 20px 12px 20px;
 }
 


### PR DESCRIPTION
## 📌 PR 개요
- 대시보드 아이템 2줄인 경우 간격 벌어지는 문제 수정

<!--
- 변경 내용을 간단하게 설명해주세요.
-->

## 🔍 변경 사항
- jobSection에 align-content: flex-start 값 추가

<!--
- 주요 변경 사항을 목록 형태로 작성해주세요.
  - 예) 로그인 페이지 UI 수정
  - 예) API 호출 로직 리팩터링
-->

## ✅ 체크리스트
- [ ] 

<!--
- [ ] 코드 빌드 및 테스트 완료
- [ ] 린트 검사 통과
- [ ] 관련 이슈에 연결 (예: Closes #123)
-->

## 📝 관련 이슈
- #2 

<!--
- 이 PR이 해결하는 이슈 번호를 적어주세요. (예: Closes #45)
-->

## 📷 스크린샷 (선택)

<img width="2548" height="1296" alt="스크린샷 2025-08-12 오후 12 45 03" src="https://github.com/user-attachments/assets/6ed82a14-7fff-418f-a3ca-6d74289cebeb" />


<!--
- UI 변경이 있다면 스크린샷이나 GIF를 첨부해주세요.
-->

## 💬 기타
- 

<!--
- 리뷰어가 참고할 추가 내용이 있다면 작성해주세요.
-->
