### PR TITLE
[Fix] 리프레시토큰 쿠키 중복 에러 수정

### DIFF
--- a/src/app/api/auth/bootstrap/route.ts
+++ b/src/app/api/auth/bootstrap/route.ts
@@ -38,50 +38,17 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const setCookieHeader = response.headers.get('Set-Cookie');
-    let newRefreshToken = null;
-    if (setCookieHeader) {
-      // Set-Cookie 헤더 파싱
-      const cookies = setCookieHeader
-        .split(/,(?=\s*\w+=)/)
-        .map((c) => c.trim());
-      for (const cookie of cookies) {
-        if (cookie.startsWith('refresh=')) {
-          newRefreshToken = cookie.split('=')[1].split(';')[0];
-          break;
-        }
-      }
-    }
-
-    const accessToken = data.data;
-    if (!accessToken) {
-      return NextResponse.redirect(
-        new URL(
-          `/api/member/logout?error=${ERROR_CODES.TOKEN_REISSUE_FAILED}`,
-          request.url
-        ),
-        {
-          status: 303,
-        }
-      );
-    }
-
     const nextResponse = NextResponse.redirect(new URL(redirect, request.url), {
       status: 303,
     });
 
     // 새로운 리프레시 토큰 재설정
-    if (newRefreshToken) {
-      nextResponse.cookies.set('refresh', newRefreshToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        maxAge: 60 * 60 * 24 * 7, // 7일
-        path: '/',
-      });
+    const setCookie = response?.headers.get('set-cookie');
+    if (setCookie) {
+      nextResponse.headers.set('set-cookie', setCookie);
     }
 
-    nextResponse.cookies.set('access_token', accessToken, {
+    nextResponse.cookies.set('access_token', data.data, {
       httpOnly: true,
       path: '/',
       secure: process.env.NODE_ENV === 'production',

--- a/src/app/api/member/logout/route.ts
+++ b/src/app/api/member/logout/route.ts
@@ -6,6 +6,7 @@ import { API_BASE_URL } from '@/lib/config';
 // 로그아웃 리다이렉트로 들어온 경우
 export async function GET(request: NextRequest) {
   let redirectParams = '';
+  let response: Response | null = null;
   const searchParams = request.nextUrl.searchParams;
   const errorCode = searchParams.get('error');
   const refreshToken = request.cookies.get('refresh')?.value ?? null;
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
   if (refreshToken) {
     try {
       // 백엔드 서버로 로그아웃 요청
-      const response = await fetch(`${API_BASE_URL}/member/logout`, {
+      response = await fetch(`${API_BASE_URL}/member/logout`, {
         method: 'POST',
         headers: {
           Cookie: `refresh=${refreshToken}`,
@@ -34,8 +35,6 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  console.log(redirectParams);
-
   const nextResponse = NextResponse.redirect(
     new URL(`/${redirectParams}`, request.url),
     {
@@ -43,8 +42,13 @@ export async function GET(request: NextRequest) {
     }
   );
 
+  // 새로운 리프레시 토큰 재설정
+  const setCookie = response?.headers.get('set-cookie');
+  if (setCookie) {
+    nextResponse.headers.set('set-cookie', setCookie);
+  }
+
   // 쿠키 토큰 삭제
-  nextResponse.cookies.delete('refresh');
   nextResponse.cookies.delete('access_token');
 
   // 클라이언트 캐시 제거하는 플래그
@@ -96,8 +100,13 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  // 새로운 리프레시 토큰 재설정
+  const setCookie = response?.headers.get('set-cookie');
+  if (setCookie) {
+    nextResponse.headers.set('set-cookie', setCookie);
+  }
+
   // 쿠키 토큰 삭제
-  nextResponse.cookies.delete('refresh');
   nextResponse.cookies.delete('access_token');
 
   // 클라이언트 캐시 제거하는 플래그

--- a/src/app/api/member/reissue/route.ts
+++ b/src/app/api/member/reissue/route.ts
@@ -37,45 +37,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const setCookieHeader = response.headers.get('Set-Cookie');
-    let newRefreshToken = null;
-    if (setCookieHeader) {
-      // Set-Cookie 헤더 파싱
-      const cookies = setCookieHeader
-        .split(/,(?=\s*\w+=)/)
-        .map((c) => c.trim());
-      for (const cookie of cookies) {
-        if (cookie.startsWith('refresh=')) {
-          newRefreshToken = cookie.split('=')[1].split(';')[0];
-          break;
-        }
-      }
-    }
-
-    const accessToken = data.data;
-    if (!accessToken) {
-      return NextResponse.json(
-        {
-          errorCode: ERROR_CODES.TOKEN_REISSUE_FAILED,
-          message: ERROR_MESSAGES.TOKEN_REISSUE_FAILED,
-        },
-        { status: response.status }
-      );
-    }
-
     const nextResponse = NextResponse.json(data, { status: response.status });
+
     // 새로운 리프레시 토큰 재설정
-    if (newRefreshToken) {
-      nextResponse.cookies.set('refresh', newRefreshToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        maxAge: 60 * 60 * 24 * 7, // 7일
-        path: '/',
-      });
+    const setCookie = response?.headers.get('set-cookie');
+    if (setCookie) {
+      nextResponse.headers.set('set-cookie', setCookie);
     }
+
     // 액세스 토큰 설정
-    nextResponse.cookies.set('access_token', accessToken, {
+    nextResponse.cookies.set('access_token', data.data, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',

--- a/src/app/api/member/withdrawal/route.ts
+++ b/src/app/api/member/withdrawal/route.ts
@@ -43,8 +43,13 @@ export async function DELETE(request: NextRequest) {
 
   const nextResponse = NextResponse.json(data, { status: response.status });
 
+  // 새로운 리프레시 토큰 재설정
+  const setCookie = response?.headers.get('set-cookie');
+  if (setCookie) {
+    nextResponse.headers.set('set-cookie', setCookie);
+  }
+
   // 쿠키 토큰 삭제
-  nextResponse.cookies.delete('refresh');
   nextResponse.cookies.delete('access_token');
 
   // 클라이언트 캐시 제거하는 플래그


### PR DESCRIPTION
## 📌 PR 개요

- 리프레시 토큰 쿠키가 중복되어 제대로 제거되지 않던 문제 수정

<!--
- 변경 내용을 간단하게 설명해주세요.
-->

## 🔍 변경 사항

- next 서버에서 자체적으로 리프레시 토큰 추가하던 부분 삭제
- 서버 응답 헤더 set-cookie 에서 그대로 넘겨줌

<!--
- 주요 변경 사항을 목록 형태로 작성해주세요.
  - 예) 로그인 페이지 UI 수정
  - 예) API 호출 로직 리팩터링
-->

## ✅ 체크리스트

- [ ]

<!--
- [ ] 코드 빌드 및 테스트 완료
- [ ] 린트 검사 통과
- [ ] 관련 이슈에 연결 (예: Closes #123)
-->

## 📝 관련 이슈

-

<!--
- 이 PR이 해결하는 이슈 번호를 적어주세요. (예: Closes #45)
-->

## 📷 스크린샷 (선택)

-

<!--
- UI 변경이 있다면 스크린샷이나 GIF를 첨부해주세요.
-->

## 💬 기타

-

<!--
- 리뷰어가 참고할 추가 내용이 있다면 작성해주세요.
-->
