### PR TITLE
[Feat] zustand 스토리지 가드 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, Suspense } from 'react';
+import { useShallow } from 'zustand/shallow';
 
 import section1 from '@/assets/images/section1.png';
 import section2 from '@/assets/images/section2.png';
@@ -21,7 +22,12 @@ import styles from './page.module.css';
 function HomeContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const setSnackbar = useBoundStore((state) => state.setSnackbar);
+  const { setSnackbar, resetOnboardingStore } = useBoundStore(
+    useShallow((state) => ({
+      setSnackbar: state.setSnackbar,
+      resetOnboardingStore: state.reset,
+    }))
+  );
   const { isLoggedIn } = useSession();
 
   useEffect(() => {
@@ -45,6 +51,8 @@ function HomeContent() {
 
     if (hasCleanupCookie) {
       queryClient.clear();
+      useBoundStore.persist.clearStorage();
+      resetOnboardingStore();
       document.cookie = 'clear_cache=; Max-Age=0; path=/; SameSite=Lax; Secure';
     }
   }, []);

--- a/src/components/onboarding/steps/AskCreateSimpleResume.tsx
+++ b/src/components/onboarding/steps/AskCreateSimpleResume.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { useShallow } from 'zustand/shallow';
 
 import checkbox from '@/assets/images/ic_checkbox.svg';
@@ -8,12 +9,13 @@ import Button from '@/components/common/Button';
 import { ERROR_CODES, ERROR_MESSAGES } from '@/constants/errorCode';
 import { updateIsOnboarded } from '@/lib/api/mypage/profile';
 import { HttpError } from '@/lib/HttpError';
-import { useBoundStore } from '@/stores/useBoundStore';
+import { isValidBooleanNull, useBoundStore } from '@/stores/useBoundStore';
 
 import styles from './AskCreateSimpleResume.module.css';
 
 export default function AskCreateSimpleResume() {
   const router = useRouter();
+  const [isUpdateOnboarding, setIsUpdateOnboarding] = useState(false);
   const {
     setCurrentStep,
     createSimpleResumeAnswer,
@@ -44,11 +46,14 @@ export default function AskCreateSimpleResume() {
       return;
     }
 
+    useBoundStore.persist.clearStorage();
     resetOnboardingStore();
     router.replace('/dashboard');
     // try {
+    //   setIsUpdateOnboarding(true);
     //   await updateIsOnboarded(true);
     //   // 온보딩 종료 (대시보드로)
+    //   useBoundStore.persist.clearStorage();
     //   resetOnboardingStore();
     //   router.replace('/dashboard');
     // } catch (error) {
@@ -66,6 +71,8 @@ export default function AskCreateSimpleResume() {
     //     type: 'error',
     //     message: '오류가 발생했어요. 다시 시도해주세요.',
     //   });
+    // } finally {
+    //   setIsUpdateOnboarding(false);
     // }
   };
 
@@ -76,6 +83,13 @@ export default function AskCreateSimpleResume() {
     }
     setCreateSimpleResumeAnswer((prev) => (prev === option ? null : option));
   };
+
+  // 마운트 시에만 초기값이 이상할 경우 null로 초기화
+  useEffect(() => {
+    if (!isValidBooleanNull(createSimpleResumeAnswer)) {
+      setCreateSimpleResumeAnswer(null);
+    }
+  }, []);
 
   return (
     <div className={styles.mainContent}>
@@ -138,7 +152,8 @@ export default function AskCreateSimpleResume() {
             variant={'primary'}
             style={{ width: '100%', height: '100%' }}
             onClick={handleClickNext}
-            disabled={createSimpleResumeAnswer === null}
+            disabled={createSimpleResumeAnswer === null || isUpdateOnboarding}
+            isLoading={isUpdateOnboarding}
           >
             {createSimpleResumeAnswer === false ? '가입 완료' : '다음 단계'}
           </Button>

--- a/src/components/onboarding/steps/AskHasResume.tsx
+++ b/src/components/onboarding/steps/AskHasResume.tsx
@@ -1,10 +1,11 @@
 import Image from 'next/image';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/shallow';
 
 import checkbox from '@/assets/images/ic_checkbox.svg';
 import checkboxChecked from '@/assets/images/ic_checkbox_checked.svg';
 import Button from '@/components/common/Button';
-import { useBoundStore } from '@/stores/useBoundStore';
+import { isValidBooleanNull, useBoundStore } from '@/stores/useBoundStore';
 
 import styles from './AskHasResume.module.css';
 
@@ -40,6 +41,13 @@ export default function AskHasResume() {
     }
     setHasResumeAnswer((prev) => (prev === option ? null : option));
   };
+
+  // 마운트 시에만 초기값이 이상할 경우 null로 초기화
+  useEffect(() => {
+    if (!isValidBooleanNull(hasResumeAnswer)) {
+      setHasResumeAnswer(null);
+    }
+  }, []);
 
   return (
     <div className={styles.mainContent}>

--- a/src/components/onboarding/steps/CreateResume.tsx
+++ b/src/components/onboarding/steps/CreateResume.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { useShallow } from 'zustand/shallow';
 
@@ -7,17 +8,25 @@ import EducationTab from '@/components/onboarding/steps/resume/EducationTab';
 import SkillTab from '@/components/onboarding/steps/resume/SkillTab';
 import ResumeTabs from '@/components/resume/ResumeTabs';
 import useResumeForm from '@/hooks/resume/useResumeForm';
-import { useBoundStore } from '@/stores/useBoundStore';
+import { DEFAULT_TAB, isValidTab, useBoundStore } from '@/stores/useBoundStore';
 
 import styles from './CreateResume.module.css';
 
 export default function CreateResume() {
-  const { currentTab } = useBoundStore(
+  const { currentTab, setCurrentTab } = useBoundStore(
     useShallow((state) => ({
       currentTab: state.currentTab,
+      setCurrentTab: state.setCurrentTab,
     }))
   );
   const { methods } = useResumeForm({ isOnboarding: true });
+
+  // 마운트 시에만 초기값이 이상할 경우 null로 초기화
+  useEffect(() => {
+    if (!isValidTab(currentTab)) {
+      setCurrentTab(DEFAULT_TAB);
+    }
+  }, []);
 
   return (
     <div className={styles.mainContent}>

--- a/src/components/onboarding/steps/resume/ContentTab.tsx
+++ b/src/components/onboarding/steps/resume/ContentTab.tsx
@@ -43,6 +43,7 @@ export default function ContentTab() {
   // 폼 제출
   const onSubmit: SubmitHandler<ResumeFormInput> = (data) => {
     console.log(data);
+    useBoundStore.persist.clearStorage();
     resetOnboardingStore();
     router.replace('/dashboard');
     // if (data.isNewcomer === null) return;

--- a/src/constants/onboarding.ts
+++ b/src/constants/onboarding.ts
@@ -16,3 +16,12 @@ export const ONBOARDING_STEPS = {
     stepNumber: 3,
   },
 } as const;
+
+export const ONBOARDING_STEP_LIST = [
+  'profile',
+  'ask_has_resume',
+  'ask_create_simple_resume',
+  'create_resume',
+];
+
+export const ONBOARDING_TAB_LIST = ['career', 'education', 'skill', 'content'];

--- a/src/hooks/resume/useResumeForm.ts
+++ b/src/hooks/resume/useResumeForm.ts
@@ -1,8 +1,14 @@
 import { useForm } from 'react-hook-form';
 import { useShallow } from 'zustand/shallow';
 
-import { useBoundStore } from '@/stores/useBoundStore';
-import { ResumeFormInput } from '@/types/resume';
+import {
+  isValidBooleanNull,
+  isValidCareerList,
+  isValidEducationList,
+  isValidSkillList,
+  useBoundStore,
+} from '@/stores/useBoundStore';
+import { ResumeFormInput, Career } from '@/types/resume';
 
 interface Props {
   isOnboarding?: boolean;
@@ -27,11 +33,15 @@ export default function useResumeForm({ isOnboarding = false }: Props = {}) {
 
   const defaultValues: ResumeFormInput = isOnboarding
     ? {
-        isNewcomer: isNewcomerAnswer,
-        careerList: careerListAnswer,
-        educationList: educationListAnswer,
-        skillList: skillListAnswer,
-        content: contentAnswer,
+        isNewcomer: isValidBooleanNull(isNewcomerAnswer)
+          ? isNewcomerAnswer
+          : null,
+        careerList: isValidCareerList(careerListAnswer) ? careerListAnswer : [],
+        educationList: isValidEducationList(educationListAnswer)
+          ? educationListAnswer
+          : [],
+        skillList: isValidSkillList(skillListAnswer) ? skillListAnswer : [],
+        content: typeof contentAnswer === 'string' ? contentAnswer : '',
       }
     : {
         isNewcomer: null,

--- a/src/stores/useBoundStore.ts
+++ b/src/stores/useBoundStore.ts
@@ -2,6 +2,13 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 import {
+  ONBOARDING_STEP_LIST,
+  ONBOARDING_TAB_LIST,
+} from '@/constants/onboarding';
+import { EDUCATION_LEVELS, EDUCATION_STATUSES } from '@/constants/resume';
+import { Career, Education } from '@/types/resume';
+
+import {
   createGlobalErrorSlice,
   GlobalErrorSlice,
 } from './slices/globalErrorSlice';
@@ -12,10 +19,86 @@ import {
 import { createResumeSlice, ResumeSlice } from './slices/resumeSlice';
 import { createSnackbarSlice, SnackbarSlice } from './slices/snackbarSlice';
 
+export const DEFAULT_STEP = 'profile' as const;
+export const DEFAULT_TAB = 'career' as const;
+export const isValidStep = (
+  step: unknown
+): step is OnboardingSlice['currentStep'] => {
+  return typeof step === 'string' && ONBOARDING_STEP_LIST.includes(step);
+};
+
+export const isValidTab = (
+  tab: unknown
+): tab is OnboardingSlice['currentTab'] => {
+  return typeof tab === 'string' && ONBOARDING_TAB_LIST.includes(tab);
+};
+
+export const isValidBooleanNull = (value: unknown): value is boolean => {
+  return typeof value === 'boolean' || value === null;
+};
+
+export const isValidCareerList = (value: unknown): value is Career[] => {
+  if (!Array.isArray(value)) return false;
+  return value.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      typeof (item as Career).companyName === 'string' &&
+      typeof (item as Career).joinedAt === 'string' &&
+      typeof (item as Career).quitAt === 'string' &&
+      typeof (item as Career).workPerformance === 'string' &&
+      typeof (item as Career).working === 'boolean'
+  );
+};
+
+export const isValidEducationList = (value: unknown): value is string[] => {
+  if (!Array.isArray(value)) return false;
+  return value.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      typeof (item as Education).level === 'string' &&
+      EDUCATION_LEVELS.values().some(
+        (level) => level.value === (item as Education).level
+      ) &&
+      typeof (item as Education).majorField === 'string' &&
+      typeof (item as Education).status === 'string' &&
+      EDUCATION_STATUSES.values().some(
+        (status) => status.value === (item as Education).status
+      )
+  );
+};
+
+export const isValidSkillList = (
+  value: unknown
+): value is { id: string; name: string }[] => {
+  if (!Array.isArray(value)) return false;
+  return value.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      typeof (item as { id: string; name: string }).id === 'string' &&
+      typeof (item as { id: string; name: string }).name === 'string'
+  );
+};
+
 type BoundStore = ResumeSlice &
   SnackbarSlice &
   GlobalErrorSlice &
   OnboardingSlice;
+
+type Persisted = Pick<
+  BoundStore,
+  | 'currentStep'
+  | 'currentTab'
+  | 'hasResumeAnswer'
+  | 'createSimpleResumeAnswer'
+  | 'isNewcomerAnswer'
+  | 'careerListAnswer'
+  | 'educationListAnswer'
+  | 'skillListAnswer'
+  | 'contentAnswer'
+>;
 
 export const useBoundStore = create<BoundStore>()(
   persist(
@@ -27,7 +110,7 @@ export const useBoundStore = create<BoundStore>()(
     }),
     {
       name: 'bound-store',
-      partialize: (state) => ({
+      partialize: (state): Persisted => ({
         currentStep: state.currentStep,
         currentTab: state.currentTab,
         hasResumeAnswer: state.hasResumeAnswer,
@@ -38,6 +121,49 @@ export const useBoundStore = create<BoundStore>()(
         skillListAnswer: state.skillListAnswer,
         contentAnswer: state.contentAnswer,
       }),
+      version: 1,
+      migrate: (state, fromVersion) => {
+        const persistedState = (state ?? {}) as Partial<Persisted>;
+        if (fromVersion === 0) {
+          if (!isValidStep(persistedState.currentStep)) {
+            persistedState.currentStep = DEFAULT_STEP;
+          }
+          if (!isValidTab(persistedState.currentTab)) {
+            persistedState.currentTab = DEFAULT_TAB;
+          }
+        }
+        return persistedState as Persisted;
+      },
+      onRehydrateStorage: () => (state) => {
+        if (!state) return;
+        if (!isValidStep(state.currentStep)) {
+          state.setCurrentStep(DEFAULT_STEP);
+        }
+        if (!isValidTab(state.currentTab)) {
+          state.setCurrentTab(DEFAULT_TAB);
+        }
+        if (!isValidBooleanNull(state.hasResumeAnswer)) {
+          state.setHasResumeAnswer(null);
+        }
+        if (!isValidBooleanNull(state.createSimpleResumeAnswer)) {
+          state.setCreateSimpleResumeAnswer(null);
+        }
+        if (!isValidBooleanNull(state.isNewcomerAnswer)) {
+          state.setIsNewcomerAnswer(null);
+        }
+        if (!isValidCareerList(state.careerListAnswer)) {
+          state.setCareerListAnswer([]);
+        }
+        if (!isValidEducationList(state.educationListAnswer)) {
+          state.setEducationListAnswer([]);
+        }
+        if (!isValidSkillList(state.skillListAnswer)) {
+          state.setSkillListAnswer([]);
+        }
+        if (typeof state.contentAnswer !== 'string') {
+          state.setContentAnswer('');
+        }
+      },
     }
   )
 );


### PR DESCRIPTION
## 📌 PR 개요

- zustand 스토리지 가드 

<!--
- 변경 내용을 간단하게 설명해주세요.
-->

## 🔍 변경 사항

- persist 로 로컬스토리지에 저장되는 값 앱으로 초기화 시킬 때 에러 발생하지 않게 가드 추가
- migrate -> 이전에 저장되어 있던 값이 현재 버전과 달라져서 버전 0이면 초기화 시키는 부분 추가
- onRehydrate 에서 마운트 되기 전에 값 유효성 체크하고 문제 있는 경우 초기화
- useForm 내에서도 초기화 하기 전 값 검증하고 주입
- UI에서 바로 값 사용하는 경우에도 useEffect로 마운트 되기 전에 검증 추가
- 온보딩 끝나거나, 로그아웃 시 persist 되는 값 초기화 추가

<!--
- 주요 변경 사항을 목록 형태로 작성해주세요.
  - 예) 로그인 페이지 UI 수정
  - 예) API 호출 로직 리팩터링
-->

## ✅ 체크리스트

- [ ]

<!--
- [ ] 코드 빌드 및 테스트 완료
- [ ] 린트 검사 통과
- [ ] 관련 이슈에 연결 (예: Closes #123)
-->

## 📝 관련 이슈

-

<!--
- 이 PR이 해결하는 이슈 번호를 적어주세요. (예: Closes #45)
-->

## 📷 스크린샷 (선택)

-

<!--
- UI 변경이 있다면 스크린샷이나 GIF를 첨부해주세요.
-->

## 💬 기타

-

<!--
- 리뷰어가 참고할 추가 내용이 있다면 작성해주세요.
-->
