### PR TITLE
[Fix] 회원탈퇴 문구 에러코드 추가, 홈에서 스낵바 안뜨는 문제 수정

### DIFF
--- a/src/app/(with-auth)/(with-footer)/mypage/page.tsx
+++ b/src/app/(with-auth)/(with-footer)/mypage/page.tsx
@@ -117,11 +117,7 @@ export default function MyPage() {
 
     withdrawalMutation(undefined, {
       onSuccess: () => {
-        setSnackbar({
-          type: 'success',
-          message: '탈퇴가 완료되었습니다.',
-        });
-        router.replace('/');
+        window.location.href = `/?error=${ERROR_CODES.WITHDRAWAL_COMPLETED}`;
       },
     });
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, Suspense } from 'react';
-import { useShallow } from 'zustand/shallow';
 
 import section1 from '@/assets/images/section1.png';
 import section2 from '@/assets/images/section2.png';
@@ -22,12 +21,8 @@ import styles from './page.module.css';
 function HomeContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { setSnackbar, resetOnboardingStore } = useBoundStore(
-    useShallow((state) => ({
-      setSnackbar: state.setSnackbar,
-      resetOnboardingStore: state.reset,
-    }))
-  );
+  const setSnackbar = useBoundStore((state) => state.setSnackbar);
+
   const { isLoggedIn } = useSession();
 
   useEffect(() => {
@@ -39,7 +34,9 @@ function HomeContent() {
     setSnackbar({ type: 'error', message });
 
     // URL에서 에러 파라미터 제거
-    router.replace('/');
+    const url = new URL(window.location.href);
+    url.searchParams.delete('error'); // 필요에 맞게 수정/추가
+    window.history.replaceState(null, '', url.toString());
   }, [searchParams, setSnackbar, router]);
 
   // 로그아웃, 회원탈퇴 시 쿼리 캐시 제거
@@ -51,8 +48,7 @@ function HomeContent() {
 
     if (hasCleanupCookie) {
       queryClient.clear();
-      useBoundStore.persist.clearStorage();
-      resetOnboardingStore();
+      localStorage.removeItem('bound-store');
       document.cookie = 'clear_cache=; Max-Age=0; path=/; SameSite=Lax; Secure';
     }
   }, []);

--- a/src/constants/errorCode.ts
+++ b/src/constants/errorCode.ts
@@ -8,6 +8,7 @@ export const ERROR_CODES = {
   NEXT_SERVER_ERROR: 'NEXT_SERVER_ERROR',
   REPLAY_REQUIRED: 'REPLAY_REQUIRED',
   LOGOUT_COMPLETED: 'LOGOUT_COMPLETED',
+  WITHDRAWAL_COMPLETED: 'WITHDRAWAL_COMPLETED',
 
   // Auth 관련
   NOT_FOUND_TOKEN: 'NOT_FOUND_TOKEN',
@@ -65,6 +66,7 @@ export const ERROR_MESSAGES = {
     '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
   REPLAY_REQUIRED: '세션이 끊겼습니다. 다시 시도해 주세요.',
   LOGOUT_COMPLETED: '로그아웃 되었습니다.',
+  WITHDRAWAL_COMPLETED: '탈퇴가 완료되었습니다.',
 
   // Auth 관련
   NOT_FOUND_TOKEN: '유효하지 않은 로그인 정보입니다. 다시 시도해 주세요.',


### PR DESCRIPTION
## 📌 PR 개요

- 로그아웃 문구 에러코드 추가, 홈에서 스낵바 안뜨는 문제 수정
 
<!--
- 변경 내용을 간단하게 설명해주세요.
-->

## 🔍 변경 사항

- 클리어 쿠키 세팅 시 zustand persist store reset 대신 localstorage에서 'bount-store' 제거하는 것으로 수정
- 회원탈퇴 시 홈 - 에러코드로 보내서 스낵바 세팅되도록 수정

<!--
- 주요 변경 사항을 목록 형태로 작성해주세요.
  - 예) 로그인 페이지 UI 수정
  - 예) API 호출 로직 리팩터링
-->

## ✅ 체크리스트

- [ ]

<!--
- [ ] 코드 빌드 및 테스트 완료
- [ ] 린트 검사 통과
- [ ] 관련 이슈에 연결 (예: Closes #123)
-->

## 📝 관련 이슈

-

<!--
- 이 PR이 해결하는 이슈 번호를 적어주세요. (예: Closes #45)
-->

## 📷 스크린샷 (선택)

-

<!--
- UI 변경이 있다면 스크린샷이나 GIF를 첨부해주세요.
-->

## 💬 기타

-

<!--
- 리뷰어가 참고할 추가 내용이 있다면 작성해주세요.
-->
