### PR TITLE
[Fix] 공고 상세 페이지 디자인 수정

### DIFF
--- a/src/app/(with-auth)/(with-footer)/job/create/page.tsx
+++ b/src/app/(with-auth)/(with-footer)/job/create/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import arrowBackIcon from '@/assets/images/ic_arrow_back.svg';
 import JobPostingForm from '@/components/job/form/JobPostingForm';
@@ -24,6 +24,7 @@ export default function CreateJobPage() {
       : null;
   const { data, isLoading, isError, error } = useJdQuery({ jobId });
   const [nextJdId, setNextJdId] = useState<number | null>(null);
+  const [showLoadingModal, setShowLoadingModal] = useState(false);
 
   const { createJdMutate, isCreatePending, isCreateSuccess } =
     useCreateJdMutation();
@@ -32,6 +33,9 @@ export default function CreateJobPage() {
     createJdMutate(data, {
       onSuccess: (data) => {
         setNextJdId(data.jd_id);
+      },
+      onError: () => {
+        setShowLoadingModal(false);
       },
     });
   };
@@ -51,6 +55,18 @@ export default function CreateJobPage() {
     `채용공고 등록 | 조각조각`,
     'AI가 분석할 채용공고를 등록합니다.'
   );
+
+  useEffect(() => {
+    if (isCreatePending) {
+      setShowLoadingModal(true);
+      return;
+    }
+
+    if (isError || error) {
+      setShowLoadingModal(false);
+      return;
+    }
+  }, [isCreatePending, isError, error]);
 
   return (
     <>
@@ -88,7 +104,8 @@ export default function CreateJobPage() {
         </div>
       </main>
       <LoadingModal
-        isOpen={isCreatePending}
+        isOpen={showLoadingModal}
+        onClose={() => setShowLoadingModal(false)}
         isComplete={isCreateSuccess}
         onCompleteAnimationEnd={handleCompleteAnimationEnd}
       />

--- a/src/app/(with-auth)/job/[id]/page.module.css
+++ b/src/app/(with-auth)/job/[id]/page.module.css
@@ -11,6 +11,13 @@
   padding-bottom: 60px;
 }
 
+.topBarContainer {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .topBar {
   position: relative;
   box-sizing: border-box;
@@ -20,6 +27,7 @@
   max-width: 1561px;
   width: 100%;
   padding: 0 20px;
+  background-color: transparent;
 }
 
 .content {
@@ -86,6 +94,16 @@
   height: 48px;
 }
 
+@media screen and (max-width: 1599px) {
+  .topBarContainer {
+    background-color: var(--n-0);
+  }
+
+  .content {
+    max-width: 809px;
+  }
+}
+
 @media screen and (max-width: 1079px) {
   .main {
     padding-bottom: 150px;
@@ -118,7 +136,6 @@
 @media screen and (max-width: 547px) {
   .topBar {
     padding: 0 8px;
-    background-color: var(--n-0);
     margin-bottom: 8px;
   }
 }

--- a/src/app/(with-auth)/job/[id]/page.tsx
+++ b/src/app/(with-auth)/job/[id]/page.tsx
@@ -256,20 +256,22 @@ export default function JobDetailPage() {
 
   return (
     <main className={styles.main}>
-      <div className={styles.topBar}>
-        <JobDetailTopBar
-          jdDetail={jdDetail}
-          handleClickJobUrl={handleClickJobUrl}
-          toggleBookmark={() =>
-            handleBookmarkToggle(jdDetail?.jd_id, !jdDetail?.bookmark)
-          }
-          onSelect={(action) => {
-            if (action === 'edit') return handleJobEdit(jdDetail?.jd_id);
-            if (action === 'delete') return setIsJdDeleting(true);
-            if (action === 'apply')
-              return handleMarkAsApplied(jdDetail?.jd_id, jdDetail?.applyAt);
-          }}
-        />
+      <div className={styles.topBarContainer}>
+        <div className={styles.topBar}>
+          <JobDetailTopBar
+            jdDetail={jdDetail}
+            handleClickJobUrl={handleClickJobUrl}
+            toggleBookmark={() =>
+              handleBookmarkToggle(jdDetail?.jd_id, !jdDetail?.bookmark)
+            }
+            onSelect={(action) => {
+              if (action === 'edit') return handleJobEdit(jdDetail?.jd_id);
+              if (action === 'delete') return setIsJdDeleting(true);
+              if (action === 'apply')
+                return handleMarkAsApplied(jdDetail?.jd_id, jdDetail?.applyAt);
+            }}
+          />
+        </div>
       </div>
 
       <div className={styles.content}>

--- a/src/app/(with-auth)/job/[id]/page.tsx
+++ b/src/app/(with-auth)/job/[id]/page.tsx
@@ -292,6 +292,7 @@ export default function JobDetailPage() {
                   icon={icon}
                   plusIcon={plusIcon}
                   todoList={todoList}
+                  originalTodoList={jdDetail.toDoLists}
                   jdId={jdDetail.jd_id}
                 />
               );

--- a/src/app/api/member/my-page/route.ts
+++ b/src/app/api/member/my-page/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ERROR_CODES, ERROR_MESSAGES } from '@/constants/errorCode';
 import { API_BASE_URL } from '@/lib/config';
 
-export async function PATCH(request: NextRequest) {
+export async function GET(request: NextRequest) {
   try {
     const accessToken = request.cookies.get('access_token')?.value ?? null;
     if (!accessToken) {
@@ -15,28 +15,19 @@ export async function PATCH(request: NextRequest) {
         { status: 401 }
       );
     }
-    const body = await request.json();
-
     // 백엔드 서버로 요청
-    const response = await fetch(
-      `${API_BASE_URL}/member/my-page/update-is-onboarded`,
-      {
-        method: 'PATCH',
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body),
-      }
-    );
+    const response = await fetch(`${API_BASE_URL}/member/my-page`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
 
     const data = await response.json();
     return NextResponse.json(data, { status: response.status });
   } catch (error) {
-    console.error(
-      'Next server error [PATCH /api/member/my_page/update]: ',
-      error
-    );
+    console.error('Next server error [GET /api/member/my-page]: ', error);
     return NextResponse.json(
       {
         errorCode: ERROR_CODES.NEXT_SERVER_ERROR,

--- a/src/app/api/member/my-page/update-is-onboarded/route.ts
+++ b/src/app/api/member/my-page/update-is-onboarded/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ERROR_CODES, ERROR_MESSAGES } from '@/constants/errorCode';
 import { API_BASE_URL } from '@/lib/config';
 
-export async function GET(request: NextRequest) {
+export async function PATCH(request: NextRequest) {
   try {
     const accessToken = request.cookies.get('access_token')?.value ?? null;
     if (!accessToken) {
@@ -15,19 +15,28 @@ export async function GET(request: NextRequest) {
         { status: 401 }
       );
     }
+    const body = await request.json();
+
     // 백엔드 서버로 요청
-    const response = await fetch(`${API_BASE_URL}/member/my-page`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-    });
+    const response = await fetch(
+      `${API_BASE_URL}/member/my-page/update-is-onboarded`,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      }
+    );
 
     const data = await response.json();
     return NextResponse.json(data, { status: response.status });
   } catch (error) {
-    console.error('Next server error [GET /api/member/my_page]: ', error);
+    console.error(
+      'Next server error [PATCH /api/member/my-page/update-is-onboarded]: ',
+      error
+    );
     return NextResponse.json(
       {
         errorCode: ERROR_CODES.NEXT_SERVER_ERROR,

--- a/src/app/api/member/my-page/update/route.ts
+++ b/src/app/api/member/my-page/update/route.ts
@@ -31,7 +31,7 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json(data, { status: response.status });
   } catch (error) {
     console.error(
-      'Next server error [PATCH /api/member/my_page/update]: ',
+      'Next server error [PATCH /api/member/my-page/update]: ',
       error
     );
     return NextResponse.json(

--- a/src/components/LoadingModal.tsx
+++ b/src/components/LoadingModal.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
@@ -42,12 +40,14 @@ const LOADING_TIPS = [
 
 interface LoadingModalProps {
   isOpen: boolean;
+  onClose: () => void;
   isComplete?: boolean;
   onCompleteAnimationEnd?: () => void;
 }
 
 export default function LoadingModal({
   isOpen,
+  onClose,
   isComplete = false,
   onCompleteAnimationEnd,
 }: LoadingModalProps) {
@@ -62,13 +62,14 @@ export default function LoadingModal({
       // 완료 애니메이션 후 콜백 실행
       const timer = setTimeout(() => {
         onCompleteAnimationEnd?.();
-      }, 1500); // 1.5초 후 이동
+        onClose();
+      }, 500); // 0.5초 후 이동
 
       return () => clearTimeout(timer);
     }
-  }, [isComplete, onCompleteAnimationEnd]);
+  }, [isComplete, onCompleteAnimationEnd, onClose]);
 
-  // 10초마다 팁 변경
+  // 2초마다 팁 변경
   useEffect(() => {
     if (!isOpen || isComplete) return;
 
@@ -81,7 +82,7 @@ export default function LoadingModal({
         }
         return newIndex;
       });
-    }, 10000); // 10초
+    }, 2000); // 2초
 
     return () => clearInterval(interval);
   }, [isOpen, isComplete]);

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -20,7 +20,7 @@ function ProgressSegment({
     <div
       className={`${styles.segment} ${isActive ? styles.active : styles.default} ${isDayover ? styles.dayover : ''} ${className}`}
     >
-      {isActiveLast && isActive && (
+      {isActiveLast && isActive && !isDayover && (
         <Image
           src={progressIcon}
           alt={'progress active icon'}

--- a/src/components/TodoModal.tsx
+++ b/src/components/TodoModal.tsx
@@ -16,9 +16,9 @@ import ErrorMessage from './common/ErrorMessage';
 import styles from './TodoModal.module.css';
 
 const CATEGORY_LABEL = {
-  STRUCTURAL_COMPLEMENT_PLAN: '구조적 보완 계획',
-  CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL: '내용 강조 및 재구성 제안',
-  SCHEDULE_MISC_ERROR: '일정 및 기타 오류',
+  STRUCTURAL_COMPLEMENT_PLAN: '필요한 경험과 역량',
+  CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL: '내용 강조 및 재구성',
+  SCHEDULE_MISC_ERROR: '취업 일정 및 기타',
 };
 
 interface BaseProps {
@@ -29,6 +29,7 @@ interface BaseProps {
 
 interface CreateProps extends BaseProps {
   mode: 'create';
+  listCategory: TodoCategory;
 }
 
 interface EditProps extends BaseProps {
@@ -40,6 +41,7 @@ type Props = CreateProps | EditProps;
 
 export default function TodoModal(props: Props) {
   const { isOpen, onClose, jdId, mode } = props;
+  const listCategory = mode === 'create' ? props.listCategory : undefined;
   const todoItem = mode === 'edit' ? props.todoItem : undefined;
 
   const { handleSubmit, control } = useTodoItemForm({
@@ -51,7 +53,7 @@ export default function TodoModal(props: Props) {
             content: todoItem.content,
           }
         : {
-            category: 'STRUCTURAL_COMPLEMENT_PLAN' as TodoCategory,
+            category: listCategory as TodoCategory,
             title: '',
             content: '',
           },

--- a/src/components/dashboard/JobItem.tsx
+++ b/src/components/dashboard/JobItem.tsx
@@ -184,7 +184,7 @@ export default function JobItem({
                           handleMarkAsApplied(jd.jd_id, jd.applyAt);
                         }
                         if (action === 'delete') {
-                          handleJobDelete(jd.jd_id);
+                          setShowDeleteConfirmModal(true);
                         }
                       }}
                     />

--- a/src/components/jobDetail/JobDetailSummaryBar.module.css
+++ b/src/components/jobDetail/JobDetailSummaryBar.module.css
@@ -164,20 +164,25 @@
 
 /* Alarm button styles */
 .notificationBtn.alarmOn {
-  background-color: var(--primaryjogak-1);
-  border-color: var(--primaryjogak-1);
+  background-color: var(--n-0);
+  border: 1px solid var(--n-300);
 }
 
 .notificationBtn.alarmOn:hover {
-  background-color: var(--primaryjogak-2);
+  background-color: var(--n-100);
 }
 
 .notificationBtn.alarmOn .notificationBtnText {
-  color: #ffffff;
+  font-family: var(--body-2-normal-medium-font-family);
+  font-size: var(--body-2-normal-medium-font-size);
+  font-style: var(--body-2-normal-medium-font-style);
+  font-weight: var(--body-2-normal-medium-font-weight);
+  letter-spacing: var(--body-2-normal-medium-letter-spacing);
+  color: var(--n-800);
 }
 
 /* Mobile responsive */
-@media (max-width: 1079px) {
+@media (max-width: 1599px) {
   .jobSummaryBarContainer {
     flex-direction: column;
     height: auto;

--- a/src/components/jobDetail/JobDetailSummaryBar.module.css
+++ b/src/components/jobDetail/JobDetailSummaryBar.module.css
@@ -116,6 +116,10 @@
   color: var(--primaryjogak-1);
 }
 
+.completedCount.dayover {
+  color: var(--n-600);
+}
+
 .lastUpdatedText {
   font-family: var(--caption-1-medium-font-family);
   font-size: var(--caption-1-medium-font-size);

--- a/src/components/jobDetail/JobDetailSummaryBar.tsx
+++ b/src/components/jobDetail/JobDetailSummaryBar.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image';
 
 import alarmIcon from '@/assets/images/ic_alarm_on_blue.svg';
-import alarmOnIcon from '@/assets/images/ic_alarm_on_white.svg';
 import { DDayChip } from '@/components/DDayChip';
 import { ProgressBar } from '@/components/ProgressBar';
 import { JDDetail } from '@/types/jds';
@@ -77,12 +76,10 @@ export default function JobDetailSummaryBar({
           onClick={handleAlarmButtonClick}
           disabled={isTogglingAlarm}
         >
-          <Image
-            src={jdDetail.alarmOn ? alarmOnIcon : alarmIcon}
-            alt={jdDetail.alarmOn ? '알림 중' : '알림 신청'}
-            width={16}
-            height={16}
-          />
+          {!jdDetail.alarmOn && (
+            <Image src={alarmIcon} alt={'알림 신청'} width={16} height={16} />
+          )}
+
           <div className={styles.notificationBtnText}>
             {jdDetail.alarmOn ? '알림 중' : '알림 신청'}
           </div>

--- a/src/components/jobDetail/JobDetailSummaryBar.tsx
+++ b/src/components/jobDetail/JobDetailSummaryBar.tsx
@@ -22,6 +22,10 @@ export default function JobDetailSummaryBar({
   isTogglingAlarm,
   handleAlarmButtonClick,
 }: Props) {
+  const isDayover =
+    calculateDDay(jdDetail.endedAt) !== null &&
+    calculateDDay(jdDetail.endedAt)! < 0;
+
   return (
     <div className={styles.jobSummaryBarContainer}>
       <div className={styles.leftSection}>
@@ -47,7 +51,9 @@ export default function JobDetailSummaryBar({
             <div className={styles.progressCounter}>
               <div className={styles.progressCounterText}>이력서 완성도</div>
               <p className={styles.progressCount}>
-                <span className={styles.completedCount}>
+                <span
+                  className={`${styles.completedCount} ${isDayover ? styles.dayover : ''}`}
+                >
                   {jdDetail.completedPieces}
                 </span>
                 <span className={styles.totalCount}>
@@ -63,6 +69,7 @@ export default function JobDetailSummaryBar({
           <ProgressBar
             total={jdDetail.totalPieces}
             completed={jdDetail.completedPieces}
+            isDayover={isDayover}
           />
         </div>
         <button

--- a/src/components/jobDetail/JobDetailTopBar.module.css
+++ b/src/components/jobDetail/JobDetailTopBar.module.css
@@ -108,9 +108,3 @@
     gap: 8px;
   }
 }
-
-/* @media (max-width: 547px) {
-  .JobDetailTopBar {
-    height: 48px;
-  }
-} */

--- a/src/components/jobDetail/JogakTodoEmptyItem.module.css
+++ b/src/components/jobDetail/JogakTodoEmptyItem.module.css
@@ -1,0 +1,22 @@
+.todoItem {
+  box-sizing: border-box;
+  width: 100%;
+  height: 134px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 32px;
+  gap: 16px;
+  border-radius: 12px;
+  background-color: var(--n-50);
+  box-shadow: 0px 2px 8px 0 rgba(93, 156, 251, 0.04);
+}
+
+.title {
+  font-family: var(--body-2-normal-medium-font-family);
+  font-size: var(--body-2-normal-medium-font-size);
+  font-style: var(--body-2-normal-medium-font-style);
+  font-weight: var(--body-2-normal-medium-font-weight);
+  letter-spacing: var(--body-2-normal-medium-letter-spacing);
+  color: var(--n-800);
+}

--- a/src/components/jobDetail/JogakTodoEmptyItem.tsx
+++ b/src/components/jobDetail/JogakTodoEmptyItem.tsx
@@ -1,0 +1,28 @@
+import Button from '@/components/common/Button';
+
+import styles from './JogakTodoEmptyItem.module.css';
+
+interface Props {
+  title: string;
+  buttonLabel: string;
+  onClick: () => void;
+}
+
+export default function JogakTodoEmptyItem({
+  title,
+  buttonLabel,
+  onClick,
+}: Props) {
+  return (
+    <div className={styles.todoItem}>
+      <p className={styles.title}>{title}</p>
+      <Button
+        onClick={onClick}
+        variant={'secondary'}
+        style={{ padding: '12px 37px', width: '100%', height: '48px' }}
+      >
+        {buttonLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/jobDetail/JogakTodoList.tsx
+++ b/src/components/jobDetail/JogakTodoList.tsx
@@ -41,10 +41,11 @@ export default function JogakTodoList({
   const [showTodoList, setShowTodoList] = useState(true);
   const resume = useBoundStore((state) => state.resume);
 
-  // CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL 카테고리에 할 일 항목이 하나도 없을 때
-  const hasNoCERP = originalTodoList?.some(
-    (item) => item.category === 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL'
-  );
+  const hasItems = (category: TodoCategory) => {
+    return (
+      originalTodoList?.some((item) => item.category === category) ?? false
+    );
+  };
 
   const allItemsDone = (category: TodoCategory) => {
     return (
@@ -118,6 +119,7 @@ export default function JogakTodoList({
           {/* 이력서가 존재하지만 내용 강조 및 재구성 카테고리가 하나도 없을 때 */}
           {todoList.length === 0 &&
             category === 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL' &&
+            !hasItems(category as TodoCategory) &&
             !!resume && (
               <JogakTodoEmptyItem
                 title={'이력서 내용이 부족해서 표시할 내용이 없어요.'}
@@ -128,8 +130,8 @@ export default function JogakTodoList({
 
           {/* 다른 카테고리에서 모든 항목이 완료되었을 때 (완료 카테고리 제외) */}
           {todoList.length === 0 &&
-            category !== 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL' &&
             category !== 'COMPLETED_JOGAK' &&
+            hasItems(category as TodoCategory) &&
             allItemsDone(category as TodoCategory) && (
               <JogakTodoEmptyItem
                 title={'모든 조각을 완료했어요 ! 🎉'}

--- a/src/components/jobDetail/JogakTodoList.tsx
+++ b/src/components/jobDetail/JogakTodoList.tsx
@@ -2,14 +2,16 @@ import { todo } from 'node:test';
 
 import { StaticImport } from 'next/dist/shared/lib/get-img-props';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import arrowIcon from '@/assets/images/ic_navigate_next.svg';
 import JogakTodoItem from '@/components/jobDetail/JogakTodoItem';
 import TodoModal from '@/components/TodoModal';
 import { useBoundStore } from '@/stores/useBoundStore';
-import { TodoItem } from '@/types/jds';
+import { TodoCategory, TodoItem } from '@/types/jds';
 
+import JogakTodoEmptyItem from './JogakTodoEmptyItem';
 import styles from './JogakTodoList.module.css';
 import NoResumeTodoItem from './NoResumeTodoItem';
 
@@ -20,6 +22,7 @@ interface Props {
   icon: string | StaticImport;
   plusIcon: string | StaticImport | null;
   todoList: TodoItem[];
+  originalTodoList: TodoItem[];
   jdId: number;
 }
 
@@ -30,11 +33,26 @@ export default function JogakTodoList({
   icon,
   plusIcon,
   todoList,
+  originalTodoList,
   jdId,
 }: Props) {
+  const router = useRouter();
   const [showAddTodoModal, setShowAddTodoModal] = useState(false);
   const [showTodoList, setShowTodoList] = useState(true);
   const resume = useBoundStore((state) => state.resume);
+
+  // CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL 카테고리에 할 일 항목이 하나도 없을 때
+  const hasNoCERP = originalTodoList?.some(
+    (item) => item.category === 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL'
+  );
+
+  const allItemsDone = (category: TodoCategory) => {
+    return (
+      originalTodoList
+        ?.filter((item) => item.category === category)
+        .every((item) => item.done) ?? false
+    );
+  };
 
   useEffect(() => {
     const handleResize = () => {
@@ -83,16 +101,42 @@ export default function JogakTodoList({
 
       {showTodoList && (
         <>
-          {todoList.map((todo) => (
-            <JogakTodoItem
-              key={todo.checklist_id}
-              category={category}
-              todoItem={todo}
-            />
-          ))}
+          {todoList.length > 0 &&
+            todoList.map((todo) => (
+              <JogakTodoItem
+                key={todo.checklist_id}
+                category={category}
+                todoItem={todo}
+              />
+            ))}
 
-          {category === 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL' &&
+          {/* 이력서 없을 때 내용 강조 및 재구성 아이템 */}
+          {todoList.length === 0 &&
+            category === 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL' &&
             resume === null && <NoResumeTodoItem jdId={jdId} />}
+
+          {/* 이력서가 존재하지만 내용 강조 및 재구성 카테고리가 하나도 없을 때 */}
+          {todoList.length === 0 &&
+            category === 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL' &&
+            !!resume && (
+              <JogakTodoEmptyItem
+                title={'이력서 내용이 부족해서 표시할 내용이 없어요.'}
+                buttonLabel={'이력서 수정하러 가기'}
+                onClick={() => router.push('/resume/update')}
+              />
+            )}
+
+          {/* 다른 카테고리에서 모든 항목이 완료되었을 때 (완료 카테고리 제외) */}
+          {todoList.length === 0 &&
+            category !== 'CONTENT_EMPHASIS_REORGANIZATION_PROPOSAL' &&
+            category !== 'COMPLETED_JOGAK' &&
+            allItemsDone(category as TodoCategory) && (
+              <JogakTodoEmptyItem
+                title={'모든 조각을 완료했어요 ! 🎉'}
+                buttonLabel="다른 채용공고 분석하기"
+                onClick={() => router.push('/dashboard')}
+              />
+            )}
         </>
       )}
 

--- a/src/components/jobDetail/JogakTodoList.tsx
+++ b/src/components/jobDetail/JogakTodoList.tsx
@@ -148,6 +148,7 @@ export default function JogakTodoList({
           onClose={() => setShowAddTodoModal(false)}
           jdId={jdId}
           mode="create"
+          listCategory={category as TodoCategory}
         />
       )}
     </div>

--- a/src/lib/api/mypage/profile.ts
+++ b/src/lib/api/mypage/profile.ts
@@ -6,7 +6,7 @@ import { fetchWithAuth } from '../fetchWithAuth';
 
 // 마이페이지 정보 조회
 export async function getMyProfile() {
-  const response = await fetchWithAuth('/api/member/my_page', {
+  const response = await fetchWithAuth('/api/member/my-page', {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -20,7 +20,7 @@ export async function getMyProfile() {
 
 // 유저 정보 패치
 export async function updateMyProfile({ nickname }: { nickname: string }) {
-  const response = await fetchWithAuth('/api/member/my_page/update', {
+  const response = await fetchWithAuth('/api/member/my-page/update', {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
@@ -56,7 +56,7 @@ export async function toggleUserNotification() {
 // 온보딩 완료 처리
 export async function updateIsOnboarded(onboarded: boolean) {
   const response = await fetchWithAuth(
-    '/api/member/my_page/update_is_onboarded',
+    '/api/member/my-page/update-is-onboarded',
     {
       method: 'PATCH',
       headers: {


### PR DESCRIPTION
## 📌 PR 개요

- 공고 상세 페이지 디자인 수정

<!--
- 변경 내용을 간단하게 설명해주세요.
-->

## 🔍 변경 사항

- ProgressBar dayover 되었을 때 마지막 아이템 아이콘 안뜨게 수정
- 채용공고 등록 모달 로직 수정
  - 내부 타이머 시간 조정  
  - 문구 교체 10초 -> 2초
  - 완료 화면 1.5초 -> 0.5초만 보여주고 넘어감
- 조각 리스트에서 조각 없는 경우 컴포넌트 추가
  - 내용강조및 재구성 -> 이력서 수정하기로 보내는 컴포넌트 추가
  - 모든 조각 완료 시 완료 컴포넌트 추가

- 1599px 너비 이하에서는 리스트 칼럼 세 줄 보이는 부분 대신 바로 두 줄부터 보이게 수정

<!--
- 주요 변경 사항을 목록 형태로 작성해주세요.
  - 예) 로그인 페이지 UI 수정
  - 예) API 호출 로직 리팩터링
-->

## ✅ 체크리스트

- [ ]

<!--
- [ ] 코드 빌드 및 테스트 완료
- [ ] 린트 검사 통과
- [ ] 관련 이슈에 연결 (예: Closes #123)
-->

## 📝 관련 이슈

-

<!--
- 이 PR이 해결하는 이슈 번호를 적어주세요. (예: Closes #45)
-->

## 📷 스크린샷 (선택)

-

<!--
- UI 변경이 있다면 스크린샷이나 GIF를 첨부해주세요.
-->

## 💬 기타

-

<!--
- 리뷰어가 참고할 추가 내용이 있다면 작성해주세요.
-->
